### PR TITLE
feat: add --version command line option

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,14 @@
+use std::env;
+
 fn main() {
+    let args: Vec<String> = env::args().collect();
+    
+    if args.len() > 1 && args[1] == "--version" {
+        println!("cargo-dist-explore CLI v{}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
+    
     println!("CLI tool starting...");
     println!("Running command-line interface");
+    println!("Use --version to see version information");
 }


### PR DESCRIPTION
## Summary

- Adds support for `--version` flag to display CLI version information
- Demonstrates the automated release workflow validation
- This PR validates the complete automation flow: feature PR → merge → auto release PR → merge → v2.2.0 release

## Testing
- Feature tested locally and works correctly
- Will trigger automated changelog and release PR creation upon merge