### PR TITLE
fix: correct YAML indentation errors in workflow files

### DIFF
--- a/.github/workflows/changelog-pr.yml
+++ b/.github/workflows/changelog-pr.yml
@@ -144,10 +144,10 @@ jobs:
           echo "✅ Version bumped from $CURRENT_VERSION to $NEW_VERSION"
           echo "✅ Changelog generated successfully"
 
-       - name: Check for existing release PR
-         if: steps.check_commits.outputs.has_commits == 'true'
-         id: check_pr
-         run: |
+      - name: Check for existing release PR
+        if: steps.check_commits.outputs.has_commits == 'true'
+        id: check_pr
+        run: |
            set -e
            NEW_VERSION="${{ steps.version_bump.outputs.new_version }}"
            

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -42,8 +42,8 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "✅ Extracted version: $VERSION"
 
-       - name: Validate version format
-         run: |
+      - name: Validate version format
+        run: |
            VERSION="${{ steps.extract_version.outputs.version }}"
 
            # Validate semver format (basic check)
@@ -55,8 +55,8 @@ jobs:
 
            echo "✅ Version format is valid: $VERSION"
 
-       - name: Validate PR version matches code version
-         run: |
+      - name: Validate PR version matches code version
+        run: |
            PR_VERSION="${{ steps.extract_version.outputs.version }}"
            
            # Get the actual version from Cargo.toml


### PR DESCRIPTION
Quick fix for YAML syntax errors that were preventing workflows from running.

- Fixed step property indentation in both workflow files
- Workflows should now execute properly instead of failing immediately