### PR TITLE
feat: add changelog to GitHub releases

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,3 +15,5 @@ targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
+# Use changelog content for GitHub release notes
+changelog = "CHANGELOG.md"


### PR DESCRIPTION
## Summary
Configure cargo-dist to include generated changelog content in GitHub release notes instead of just using the git tag message.

This completes the release automation by ensuring release notes contain the full changelog generated by git-cliff.

**Changes:**
- Added `changelog = "CHANGELOG.md"` to `dist-workspace.toml`

**Testing:**
This PR will test the complete end-to-end release flow with changelog content in GitHub releases.